### PR TITLE
Use let* in plist-r/o

### DIFF
--- a/let-plus.lisp
+++ b/let-plus.lisp
@@ -327,8 +327,9 @@ key default)."
 
 (define-let+-expansion (&plist-r/o entries)
   "LET+ form for property lists, read only version."
-  `(let ,(expand-entry-forms entries
-                             (lambda (key default) `(getf ,value ,key ,default)))
+  `(let* ,(expand-entry-forms entries
+                              (lambda (key default)
+                                `(getf ,value ,key ,default)))
      ,@body))
 
 (define-let+-expansion (&hash-table entries)


### PR DESCRIPTION
I suggest using `let*` instead of `let` in the `&plist-r/o` expansion for two reasons:
- For parity with `&plist`. Consider

``` cl
CL-USER> (let+ (((&plist-r/o (a :a :a-default) (b :b a)) (list :c 1)))
           (values a b))
=> Evaluation aborted on #<UNBOUND-VARIABLE A {11522129}>.
CL-USER> (let+ (((&plist (a :a :a-default) (b :b a)) (list :c 1)))
           (values a b))
:A-DEFAULT
:A-DEFAULT
```
- In general, `let-plus` has `let*`-like semantic. IMHO, it would be consistent to behave in the same way for `&plist-r/o` with multiple bindings.

Of course, a workaround would be

``` cl
CL-USER> (let+ ((list (list :c 1))
                ((&plist (a :a :a-default)) list)
                ((&plist (b :b a)) list))
           (values a b))
```

but that seems a bit lengthy.
