### PR TITLE
Process declarations and docstrings correctly for flet+, labels+ ...

### DIFF
--- a/tests.lisp
+++ b/tests.lisp
@@ -178,6 +178,14 @@ should)."
     (ensure-same (foo '((1 2 3) . nil)) '(3 2 1))))
 
 (addtest (let-plus-tests)
+  test-defun+
+  (defun+ foo ((a . b))
+    "bar"
+    (+ a b))
+  (ensure-same (foo '(1 . 2)) 3)
+  (ensure-same (documentation 'foo 'function) "bar" :test #'string=))
+
+(addtest (let-plus-tests)
   test-assert
   (ensure
     (let+ ((a 1)


### PR DESCRIPTION
Commit message:

```
Process declarations and docstrings correctly for flet+, labels+, lambda+, defun+

For now, declarations are ignored instead of ending up somewhere in
the expansion.

Docstrings should appear at the correct syntactic position in the
expansion.

Added test for docstring in defun+.
```

I think this behavior is better than splicing docstrings, declarations and the actual body somewhere into the expansion.

PS: For a more comprehensive treatment of declarations a variant of which I may propose later see:
- scymtym/let-plus@491f0604fad1caa9ebb78c34071058a66c9d6c5e
- scymtym/let-plus@79234d88c57b6893ee265b0f23e79be443d6377c. 
