### PR TITLE
Merge adjacent &LABELS bindings into a single CL:LABELS form

### DIFF
--- a/let-plus.lisp
+++ b/let-plus.lisp
@@ -282,8 +282,14 @@ NOTE: It is unlikely that you need to used this function, see the note above its
                                                &body function-body)
                            :uses-value? nil)
   "LET+ form for function definitions.  Expands into an LABELS, thus allowing recursive functions."
-  `(labels ((,function-name ,lambda-list ,@function-body))
-     ,@body))
+  (if (typep (first body) '(cons (eql cl:labels)))
+      (destructuring-bind (bindings &rest first-body) (rest (first body))
+        `(labels ((,function-name ,lambda-list ,@function-body)
+                  ,@bindings)
+           ,@first-body
+           ,@(rest body)))
+      `(labels ((,function-name ,lambda-list ,@function-body))
+         ,@body)))
 
 (define-let+-expansion (&macrolet (macro-name lambda-list  &body macro-body)
                            :uses-value? nil)

--- a/tests.lisp
+++ b/tests.lisp
@@ -126,6 +126,23 @@ should)."
     (ensure-same (my-factorial 4) 24)))
 
 (addtest (let-plus-tests)
+  test-labels/mutual-recursion
+  (let+ (((&labels my-even? (x)
+            (cond
+              ((zerop x)
+               t)
+              ((plusp x)
+               (my-odd? (1- x)))
+              (t
+               nil))))
+         ((&labels my-odd? (x)
+            (my-even? (1- x)))))
+    (ensure-same (my-odd?  4) nil)
+    (ensure-same (my-even? 4) t)
+    (ensure-same (my-odd?  5) t)
+    (ensure-same (my-even? 5) nil)))
+
+(addtest (let-plus-tests)
   test-plist
   (test-r/o-and-r/w (list 'a 1 :b 2 'c '3)
                     ((a 1) (b 2) (c 3) (d 4))


### PR DESCRIPTION
Without this, let-plus cannot be used for mutually recursive local functions.
