### PR TITLE
Handle &IGN in lambda lists of &FLET+, &LABELS+, DEFUN+, etc. correctly

### DIFF
--- a/extensions.lisp
+++ b/extensions.lisp
@@ -10,10 +10,17 @@ The list starts with a lambda list, and is followed by a docstring (when provide
 Used internally, not exported."
   (let+ (((&values body declarations documentation)
           (parse-body body :documentation t))
-         (arguments (loop repeat (length lambda-list) collect (gensym))))
+         ((&values arguments bindings ignores)
+          (loop :for parameter :in lambda-list
+             :for argument = (gensym)
+             :collect argument :into arguments
+             :if (eq parameter '&ign) :collect argument :into ignores
+             :else :collect (list parameter argument) :into bindings
+             :finally (return (values arguments bindings ignores)))))
     `(,arguments
       ,@(when documentation `(,documentation))
-      (let+ ,(mapcar #'list lambda-list arguments)
+      ,@(when ignores `((declare (ignore ,@ignores))))
+      (let+ ,bindings
         ,@declarations
         ,@body))))
 

--- a/tests.lisp
+++ b/tests.lisp
@@ -175,7 +175,11 @@ should)."
             (if a
                 (foo (cons (cdr a) (cons (car a) b)))
                 b))))
-    (ensure-same (foo '((1 2 3) . nil)) '(3 2 1))))
+    (ensure-same (foo '((1 2 3) . nil)) '(3 2 1)))
+
+  (ensure-no-warning
+    (compile nil '(lambda (x)
+                    (let+ (((&labels+ foo (&ign)))) (foo x))))))
 
 (addtest (let-plus-tests)
   test-defun+


### PR DESCRIPTION
The current behavior produces an unused ``gensym``ed variable.